### PR TITLE
Fix for issue #16

### DIFF
--- a/core/components/newspublisher/model/newspublisher/newspublisher.class.php
+++ b/core/components/newspublisher/model/newspublisher/newspublisher.class.php
@@ -832,6 +832,7 @@ class Newspublisher {
                 
             } else {
 
+                $ph = str_replace(array('[',']'), array('&#91;','&#93;'), $ph);
                 $this->modx->toPlaceholder($name, $ph, $this->prefix );
             }
         }


### PR DESCRIPTION
Hi Bob

This should fix the tag rendering issue in tvs.

Since the topic is MODx tags, may I take the opportunity and ask, what you think about a more fine grained control over which tags can be edited by the user?
Sometimes I want to edit a doc containing a field tag or simple links, but NP would not allow it without allowing ALL tags. Therefore I have tried to make a prototype that parses the tags using the builtin tag parser and checks for additional permissions such as 'np_edit_links', 'np_edit_snippets', etc. This would allow users to edit/create "unproblematic" tags while editing snippets or chunks would still be forbidden. If you are interested, I could work it out a bit more and push the code to github.

Markus
