### PR TITLE
Make media source id available in file/image tpls

### DIFF
--- a/core/components/newspublisher/model/newspublisher/newspublisher.class.php
+++ b/core/components/newspublisher/model/newspublisher/newspublisher.class.php
@@ -1379,6 +1379,7 @@ class Newspublisher {
                 }
                 $source->initialize();
                 $params['source'] = $source->get('id');
+                $replace['[[+npx.source]]'] = $source->get('id');
                 
                 if (!$source->checkPolicy('view')) {
                     $this->setError($this->modx->lexicon('np_media_source_access_denied')


### PR DESCRIPTION
Great for 3rd-party file browsers to segregate volumes, and be able to accomplish an openTo