### PR TITLE
Update newspublisher.class.php

### DIFF
--- a/core/components/newspublisher/model/newspublisher/newspublisher.class.php
+++ b/core/components/newspublisher/model/newspublisher/newspublisher.class.php
@@ -1050,14 +1050,7 @@ class Newspublisher {
                 /* regular resource field */
                 $inner .= $this->_displayField($field);
             } else {
-                /* see if it's a TV */
-                /* (presets done inside  _displayTv() ) */
-
-                $retVal = $this->_displayTv($field);
-                if ($retVal) {
-                    $inner .= "\n" . $retVal;
-                }
-
+             
                 /* See if it's a chunk */
                 if ($field[0] === '$') {
                     $chunk = $this->modx->getChunk(substr($field, 1));
@@ -1065,6 +1058,13 @@ class Newspublisher {
                         $inner .= "\n" . $chunk;
                         continue;
                     }
+                }
+
+                /* see if it's a TV */
+                /* (presets done inside  _displayTv() ) */
+                $retVal = $this->_displayTv($field);
+                if ($retVal) {
+                    $inner .= "\n" . $retVal;
                 }
             }
         }


### PR DESCRIPTION
correct order of checks for $chunks. fixes issue when all $chunks are first treated as TVs and then rejected with error.